### PR TITLE
Add base pin definitions

### DIFF
--- a/pins_arduino.h
+++ b/pins_arduino.h
@@ -1,0 +1,14 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#define HW_VENDOR HardwareModel_PRIVATE_HW
+#define SDA 15
+#define SCL 18
+#define SCK 25
+#define MISO 34
+#define MOSI 21
+#define SS 27
+
+#define digitalPinToInterrupt(p) (((p) < 40) ? (p) : -1)
+
+#endif


### PR DESCRIPTION
In its current state, PlatformIO will attempt to look for `pins_arduino.h` which it can't find anywhere causing a compilation error. This commit adds the file as part of the WiPhone variant, along with the basic required pin assignments.